### PR TITLE
Add helpful package

### DIFF
--- a/emacs/modules/lang-elisp.el
+++ b/emacs/modules/lang-elisp.el
@@ -1,7 +1,29 @@
-;;; lang-elisp.elisp
+;;; lang-elisp.elisp --- Configures Emacs Lisp
 
 ;;; Code
+
+;; Helpful is a package to improve Emacs Lisp's default
+;; documentation functionality. Most importantly, Helpful
+;; will show the callpoint of a function and include its
+;; source code if it can.
+(use-package helpful
+  :after counsel
+  :init
+  (setq counsel-describe-function-function #'helpful-callable)
+  (setq counsel-describe-variable-function #'helpful-variable)
+  :bind (:map emacs-lisp-mode-map
+              ;; view interactive functions
+              ("C-h c" . helpful-command)
+              ;; describe function, macro, or special form
+              ("C-h f" . helpful-callable)
+              ;; looks up functions (excluding macros)
+              ("C-h F" . helpful-function)
+              ("C-h k" . helpful-key)
+              ("C-h v" . helpful-variable)
+              ("C-c C-d" . helpful-at-point)))
+
 (add-hook 'emacs-lisp-mode-hook (lambda ()
-				  (smartparens-strict-mode)
-				  (rainbow-delimiters-mode)))
+                                  (smartparens-strict-mode)
+                                  (rainbow-delimiters-mode)))
+
 (provide 'lang-elisp)


### PR DESCRIPTION
Helpful is a package to improve emacs lisp documentation and easily
pull up said documentation, including source code when found, for
symbols at point.

I've also hooked helpful into counsel so that those utilities are
available to counsel's describe functionality.

It's important to note that helpful is only usable for emacs lisp, which
is why I've made sure to only define the keybindings within the emacs
lisp keymap. I don't want to clobber the keymap for other modes where
those keybindings might potentially be useful.